### PR TITLE
remove link to bcdevexchange.org/projects

### DIFF
--- a/Resident-Teams/README.md
+++ b/Resident-Teams/README.md
@@ -103,5 +103,4 @@ emissions from transportation fuel.
 
 ### 100+ Apps Using DevOps and Coding in the Open
 While the BCDevExchange supports teams to deliver product in the Lab, we also make our DevOps platform available to teams outside of the Exchange lab. These teams are part of the development community helping to modernize the BC Public Service, including coding in the open. 
-* [See the list of projects and products the BCDevExchange community is working on](https://bcdevexchange.org/projects)  
 * [See Developer.gov.bc.ca - the DevHub - for how they make things happen, including our design system of reusable components.](https://developer.gov.bc.ca/)


### PR DESCRIPTION
Hi Guys,
I suggest removing this link because the projects list on bcdevexchange.org is totally random, not at all up-to-date, nor reflective of all the stuff being developed on the platform.